### PR TITLE
test with go1.20 and update golangci-lint to a specific version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         go-version:
           - 1.18
           - 1.19
+          - '1.20'
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,7 +22,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: '1.20'
 
 jobs:
   license-check:
@@ -53,5 +53,5 @@ jobs:
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         timeout-minutes: 5
         with:
-          version: latest
+          version: v1.51
           only-new-issues: true


### PR DESCRIPTION


#### Summary
- test with go1.20 and update golangci-lint to a specific version